### PR TITLE
Fixed sed command by adding single quotes to environment variable

### DIFF
--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -15,7 +15,7 @@ data:
         exit 1
       fi
       echo "Updating my IP to ${POD_IP} in ${CLUSTER_CONFIG}"
-      sed -i.bak -e '/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/'${POD_IP}'/' ${CLUSTER_CONFIG}
+      sed -i.bak -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/" ${CLUSTER_CONFIG}
     fi
     exec "$@"
   redis.conf: |+

--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -15,7 +15,7 @@ data:
         exit 1
       fi
       echo "Updating my IP to ${POD_IP} in ${CLUSTER_CONFIG}"
-      sed -i.bak -e '/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/' ${CLUSTER_CONFIG}
+      sed -i.bak -e '/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/'${POD_IP}'/' ${CLUSTER_CONFIG}
     fi
     exec "$@"
   redis.conf: |+


### PR DESCRIPTION
Now the IP address should be properly replaced. in the /data/nodes.conf file based on the POD_IP environment variable.

Fixes #8 