### PR TITLE
redis node self ip is not replaced properly

### DIFF
--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -15,7 +15,7 @@ data:
         exit 1
       fi
       echo "Updating my IP to ${POD_IP} in ${CLUSTER_CONFIG}"
-      sed -i.bak -e '/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/' ${CLUSTER_CONFIG}
+      sed -i.bak -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/" ${CLUSTER_CONFIG}
     fi
     exec "$@"
   redis.conf: |+


### PR DESCRIPTION
In the bash, single quote won't resovle the ${POD_IP} but just take the text, use double quote instead.

I tested in our environment, the IP is replaced properly.