### PR TITLE
add failover script + split configmap from statefulset

### DIFF
--- a/redis-cluster-configmap.yml
+++ b/redis-cluster-configmap.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-cluster
+  labels:
+    app: redis-cluster
+data:
+  fix-ip.sh: |
+    #!/bin/sh
+    CLUSTER_CONFIG="/data/nodes.conf"
+    if [ -f ${CLUSTER_CONFIG} ]; then
+      if [ -z "${POD_IP}" ]; then 
+        echo "Unable to determine Pod IP address!"
+        exit 1
+      fi
+      echo "Updating my IP to ${POD_IP} in ${CLUSTER_CONFIG}"
+      sed -i.bak -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/" ${CLUSTER_CONFIG}
+    fi
+    exec "$@"
+  failover.sh: |
+    #!/bin/sh
+    >/data/output.log
+    exec >>/data/output.log
+    exec 2>>/data/output.log
+    set -x
+    INFO=`redis-cli cluster nodes`
+    echo "$INFO"|awk '/myself/ {print $3}'|grep -q slave
+    if [ $? -eq 0 ]; then
+      exit 0
+    fi
+    ID=`echo "$INFO"|awk '/myself/ {print $1}'`
+    SLAVE=`echo "$INFO"|awk "/slave.*$ID/ {print \\$2}"|cut -f1 -d:`
+    OUTPUT=`redis-cli -h $SLAVE cluster failover 2>&1`
+    if [ `echo $OUTPUT|grep -c "OK"` -eq 0 ]; then
+      redis-cli -h $SLAVE cluster failover force
+    else
+      sleep 2
+    fi
+  redis.conf: |+
+    cluster-enabled yes
+    cluster-require-full-coverage no
+    cluster-node-timeout 15000
+    cluster-config-file /data/nodes.conf
+    cluster-migration-barrier 1
+    appendonly yes
+    protected-mode no

--- a/redis-cluster.yml
+++ b/redis-cluster.yml
@@ -1,33 +1,5 @@
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redis-cluster
-  labels:
-    app: redis-cluster
-data:
-  fix-ip.sh: |
-    #!/bin/sh
-    CLUSTER_CONFIG="/data/nodes.conf"
-    if [ -f ${CLUSTER_CONFIG} ]; then
-      if [ -z "${POD_IP}" ]; then 
-        echo "Unable to determine Pod IP address!"
-        exit 1
-      fi
-      echo "Updating my IP to ${POD_IP} in ${CLUSTER_CONFIG}"
-      sed -i.bak -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/" ${CLUSTER_CONFIG}
-    fi
-    exec "$@"
-  redis.conf: |+
-    cluster-enabled yes
-    cluster-require-full-coverage no
-    cluster-node-timeout 15000
-    cluster-config-file /data/nodes.conf
-    cluster-migration-barrier 1
-    appendonly yes
-    protected-mode no
----
-apiVersion: v1
 kind: Service
 metadata:
   name: redis-cluster
@@ -71,6 +43,11 @@ spec:
         - containerPort: 16379
           name: gossip
         command: ["/conf/fix-ip.sh", "redis-server", "/conf/redis.conf"]
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - "/conf/failover.sh"
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
I don't know if this may be useful for other people. I have created a pre-stop lifecycle which verifies if it is an actual master, and switches the service to its slave if so.

Also I have split the configmap from the statefulset to avoid having one big file.